### PR TITLE
pass Enumerable.Empty to DatabaseUpgradeResult rather than null since…

### DIFF
--- a/DbUp.Support.SqlServer.Scripting/ScriptingUpgrader.cs
+++ b/DbUp.Support.SqlServer.Scripting/ScriptingUpgrader.cs
@@ -87,7 +87,7 @@ namespace DbUp
 
             if (this.ConnectionString == null)
             {
-                return new DatabaseUpgradeResult(null, false, new Exception("connectionString could not be determined"));
+                return new DatabaseUpgradeResult(Enumerable.Empty<SqlScript>(), false, new Exception("connectionString could not be determined"));
             }
 
             var scripter = new DbObjectScripter(this.ConnectionString, m_options, this.Log);
@@ -109,7 +109,7 @@ namespace DbUp
 
                 if (args.Any(a => "--whatIf".Equals(a, StringComparison.InvariantCultureIgnoreCase)))
                 {
-                    result = new DatabaseUpgradeResult(null, true, null);
+                    result = new DatabaseUpgradeResult(Enumerable.Empty<SqlScript>(), true, null);
 
                     this.Log.WriteWarning("WHATIF Mode!");
                     this.Log.WriteWarning("The following scripts would have been executed:");


### PR DESCRIPTION
… null value caused exception in the DatabaseUpgradeResult constructor since it tries to AddRange to its scripts member.

```
new DatabaseUpgradeResult(null, true, null);
...
...
public DatabaseUpgradeResult(IEnumerable<SqlScript> scripts, bool successful, Exception error)
{
       this.scripts = new List<SqlScript>();
       this.scripts.AddRange(scripts);  // <= here's where the exception occured.
       this.successful = successful;
       this.error = error;
}
```
