### PR TITLE
Added support for User Defined Types

### DIFF
--- a/DbUp.Support.SqlServer.Scripting/ObjectTypeEnum.cs
+++ b/DbUp.Support.SqlServer.Scripting/ObjectTypeEnum.cs
@@ -13,6 +13,7 @@ namespace DbUp.Support.SqlServer.Scripting
         View = 2,
         Procedure = 4,
         Function = 8,
-        Synonym = 16
+        Synonym = 16,
+        Type = 32
     }
 }

--- a/DbUp.Support.SqlServer.Scripting/Options.cs
+++ b/DbUp.Support.SqlServer.Scripting/Options.cs
@@ -18,13 +18,15 @@ namespace DbUp.Support.SqlServer.Scripting
             this.FolderNameViews = "Views";
             this.FolderNameProcedures = "Procedures";
             this.FolderNameFunctions = "Functions";
+            this.FolderNameUserDefinedTypes = "UserDefinedTypes";
             this.FolderNameSynonyms = "Synonyms";
 
             this.ObjectsToInclude = ObjectTypeEnum.Function
                 | ObjectTypeEnum.Procedure
                 | ObjectTypeEnum.Synonym
                 | ObjectTypeEnum.Table
-                | ObjectTypeEnum.View;
+                | ObjectTypeEnum.View
+                | ObjectTypeEnum.Type;
 
             this.ScriptingOptions = new ScriptingOptions()
           {
@@ -39,6 +41,7 @@ namespace DbUp.Support.SqlServer.Scripting
         public string BaseFolderNameDefinitions { get; set; }
         public string FolderNameTables { get; set; }
         public string FolderNameViews { get; set; }
+        public string FolderNameUserDefinedTypes { get; set; }
         public string FolderNameProcedures { get; set; }
         public string FolderNameFunctions { get; set; }
         public string FolderNameSynonyms { get; set; }


### PR DESCRIPTION
I've added support for User Defined Types (UserDefinedTypes, UserDefinedDataTypes, UserDefinedFunctions and UserDefinedTableTypes)

Tested both generating all scripts using the `--scriptAllDefinitions` as well as just the added/dropped ones in a migration script using `--fromconsole` on an Sql Server 2014 localdb.

Need this for a project, so if there's anything I can do to help get this released swiftly don't hesitate to ask.
