### PR TITLE
Resolves #11 - DefintionScriptProvider

### DIFF
--- a/DbUp.Support.SqlServer.Scripting/DbUp.Support.SqlServer.Scripting.csproj
+++ b/DbUp.Support.SqlServer.Scripting/DbUp.Support.SqlServer.Scripting.csproj
@@ -75,6 +75,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DefinitionScriptProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ScriptingUpgrader.cs" />
     <Compile Include="DbObjectScripter.cs" />

--- a/DbUp.Support.SqlServer.Scripting/DefinitionScriptProvider.cs
+++ b/DbUp.Support.SqlServer.Scripting/DefinitionScriptProvider.cs
@@ -9,7 +9,6 @@ using DbUp.Engine.Transactions;
 
 namespace DbUp.Support.SqlServer.Scripting
 {
-
     /// <summary>
     /// This script provider will collect all the scripts in the generated Definitions folder and attempt to order
     /// them in order of dependency, the dependency searching is quite basic, as it only looks for
@@ -19,6 +18,12 @@ namespace DbUp.Support.SqlServer.Scripting
     {
         private readonly string _defintionFolderPath;
         private readonly Regex _contentReplaceRegex;
+
+        public DefinitionScriptProvider(): this("..\\..\\Definitions", "(SET ANSI_NULLS ON)|(SET ANSI_NULLS OFF)|(SET QUOTED_IDENTIFIER OFF)|(SET QUOTED_IDENTIFIER ON)")
+        {
+            
+        }
+
         public DefinitionScriptProvider(string defintionFolderPath = "..\\..\\Definitions", 
             string contentReplaceRegex = "(SET ANSI_NULLS ON)|(SET ANSI_NULLS OFF)|(SET QUOTED_IDENTIFIER OFF)|(SET QUOTED_IDENTIFIER ON)")
         {
@@ -46,6 +51,12 @@ namespace DbUp.Support.SqlServer.Scripting
         public IEnumerable<SqlScript> GetScripts(IConnectionManager connectionManager)
         {
             return GatherScriptsWithDependencies();
+        }
+
+        public string GetScriptContent()
+        {
+            var scripts = GatherScriptsWithDependencies();
+            return string.Join($"{Environment.NewLine} GO {Environment.NewLine}", scripts.Select(x => x.Contents));
         }
 
         private string GetFileContent(string path)

--- a/DbUp.Support.SqlServer.Scripting/DefinitionScriptProvider.cs
+++ b/DbUp.Support.SqlServer.Scripting/DefinitionScriptProvider.cs
@@ -19,7 +19,8 @@ namespace DbUp.Support.SqlServer.Scripting
     {
         private readonly string _defintionFolderPath;
         private readonly Regex _contentReplaceRegex;
-        public DefinitionScriptProvider(string defintionFolderPath = "..\\..\\Definitions", string contentReplaceRegex = "(SET ANSI_NULLS ON)|(SET QUOTED_IDENTIFIER ON)")
+        public DefinitionScriptProvider(string defintionFolderPath = "..\\..\\Definitions", 
+            string contentReplaceRegex = "(SET ANSI_NULLS ON)|(SET ANSI_NULLS OFF)|(SET QUOTED_IDENTIFIER OFF)|(SET QUOTED_IDENTIFIER ON)")
         {
             if (Directory.Exists(defintionFolderPath))
             {

--- a/DbUp.Support.SqlServer.Scripting/DefinitionScriptProvider.cs
+++ b/DbUp.Support.SqlServer.Scripting/DefinitionScriptProvider.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using DbUp.Engine;
+using DbUp.Engine.Transactions;
+
+namespace DbUp.Support.SqlServer.Scripting
+{
+
+    /// <summary>
+    /// This script provider will collect all the scripts in the generated Definitions folder and attempt to order
+    /// them in order of dependency, the dependency searching is quite basic, as it only looks for
+    /// references of named entries, however this could be easily extended
+    /// </summary>
+    public class DefinitionScriptProvider : IScriptProvider
+    {
+        private readonly string _defintionFolderPath;
+        private readonly Regex _contentReplaceRegex;
+        public DefinitionScriptProvider(string defintionFolderPath = "..\\..\\Definitions", string contentReplaceRegex = "(SET ANSI_NULLS ON)|(SET QUOTED_IDENTIFIER ON)")
+        {
+            if (Directory.Exists(defintionFolderPath))
+            {
+                _defintionFolderPath = new DirectoryInfo(defintionFolderPath).FullName;
+            }
+            if (_defintionFolderPath == null)
+            {
+                var possible = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), defintionFolderPath);
+                if (Directory.Exists(possible))
+                {
+                    _defintionFolderPath = new DirectoryInfo(possible).FullName;
+                }
+            }
+
+            if (_defintionFolderPath == null)
+            {
+                throw new DirectoryNotFoundException($"Path: {defintionFolderPath} not found");
+            }
+
+            _contentReplaceRegex = new Regex(contentReplaceRegex, RegexOptions.Multiline);
+        }
+
+        public IEnumerable<SqlScript> GetScripts(IConnectionManager connectionManager)
+        {
+            return GatherScriptsWithDependencies();
+        }
+
+        private string GetFileContent(string path)
+        {
+            var text = File.ReadAllText(path);
+            return _contentReplaceRegex.Replace(text, string.Empty);
+        }
+
+        private IEnumerable<Script> GatherScripts()
+        {
+            return Directory.GetFiles(_defintionFolderPath, "*.sql", SearchOption.AllDirectories)
+                .Select(x => new Script
+                {
+                    Contents = GetFileContent(x),
+                    Path = x,
+                });
+        }
+
+        private Script DiscoverDependants(IEnumerable<Script> source, Script leaf)
+        {
+            //insepct the contents of the leaf for any mentions of other entries
+            leaf.SetDependencies(source
+                //ignore the current leaf
+                .Where(x => !x.Equals(leaf))
+                //this might need to be extended it is a very basic example of finding the dependency
+                .Where(x => leaf.Contents.Contains(x.CompareName)));
+            return leaf;
+        }
+
+        private IEnumerable<SqlScript> GatherScriptsWithDependencies()
+        {
+            var source = GatherScripts().ToList();
+            var scripts = source.Select(x => DiscoverDependants(source, x)).ToList();
+            return WalkDependencies(scripts).Select(x => new SqlScript($"Definition_{x.Name}", x.Contents));
+        }
+
+        private IEnumerable<Script> WalkDependencies(List<Script> scripts)
+        {
+            //Aggregate all the scripts by walking up the parents
+            return scripts.Aggregate(new List<Script>(), AddParent);
+        }
+
+        private List<Script> AddParent(List<Script> result, Script current)
+        {
+            foreach (var currentDependency in current?.Dependencies ?? new List<Script>())
+            {
+                result = AddParent(result, currentDependency);
+                if (!result.Contains(currentDependency))
+                {
+                    result.Add(currentDependency);
+                }
+            }
+            if (!result.Contains(current))
+            {
+                result.Add(current);
+            }
+            return result;
+        }
+
+        class Script
+        {
+            public string Path { get; set; }
+            public string Name => System.IO.Path.GetFileNameWithoutExtension(Path);
+            public string CompareName => string.Join(".", Name.Split(new[] { "." }, StringSplitOptions.RemoveEmptyEntries).Select(y => $"[{y}]"));
+            public string Contents { get; set; }
+            public IEnumerable<Script> Dependencies { get; private set; }
+            public void SetDependencies(IEnumerable<Script> dependencies)
+            {
+                Dependencies = dependencies;
+            }
+
+            public override bool Equals(object obj)
+            {
+                var compare = obj as Script;
+                return compare?.Path.Equals(Path) ?? false;
+            }
+
+            public override int GetHashCode()
+            {
+                return Path.GetHashCode();
+            }
+        }
+
+        class ContentReplacement
+        {
+            public string FindText { get; set; }
+            public string ReplaceText { get; set; }
+        }
+    }
+}

--- a/build/pack/tools/dbup-sqlserver-scripting.psm1
+++ b/build/pack/tools/dbup-sqlserver-scripting.psm1
@@ -10,3 +10,43 @@ function Start-DatabaseScript {
   
   & $projectExe $args
  }
+
+
+function New-InitialScript {
+  
+    $project = get-project
+    $projectDirectory = Split-Path $project.FullName
+    #wrap in a job so type isn't locked
+    $job = Start-Job -ScriptBlock {        
+        $basePath = $args[0]
+        $binDirectory = "$basePath\bin\debug"        
+        try{
+            Add-Type -Path "$binDirectory\DbUp.dll"
+            Add-Type -Path "$binDirectory\DbUp.Support.SqlServer.Scripting.dll"
+          }
+          catch 
+          {
+            Write-Host -foreground yellow "LoadException";
+            $Error | format-list -force
+            Write-Host -foreground red $Error[0].Exception.LoaderExceptions;
+          }
+
+        $scriptProvider = new-object DbUp.Support.SqlServer.Scripting.DefinitionScriptProvider -ArgumentList "$basePath\Definitions"
+        $scriptProvider.GetScriptContent()
+    } -ArgumentList $projectDirectory
+    Wait-Job $job    
+      
+  #create scripts folder if it doesn't exist
+  $scripts = $project.ProjectItems | ?{ $_.Name.Equals("Scripts") }
+  if($scripts -eq $null){
+    $project.ProjectItems.AddFolder("Scripts")
+  }
+  #Create the new script by calling the lib
+  $initialScriptPath = "$projectDirectory\Scripts\001-initial.sql"
+  Receive-Job $job | New-Item $initialScriptPath -Force -ErrorAction Ignore
+  
+  #add to project
+  $addedItem = $project.ProjectItems.Item("Scripts").ProjectItems.AddFromFileCopy($initialScriptPath)
+  #update to embedded resource
+  $addedItem.Properties.Item("BuildAction").Value = 3
+}


### PR DESCRIPTION
 Add a script provider to order definition scripts by dependency, this can then be run against a blank db

The ordering is pretty basic, seemed to work well with a set of tables and stored procs with various foreign keys. Example usage:
```
    class Program
    {
        static int Main(string[] args)
        {
            var connectionString = @"...";
            EnsureDatabase.For.SqlDatabase(connectionString);

            var initial = DeployChanges.To
                    .SqlDatabase(connectionString)
                    .WithScripts(new DefinitionScriptProvider())
                    .LogToConsole()
                    .Build();

            var initResult = initial.PerformUpgrade();

            var upgrader = DeployChanges.To
                    .SqlDatabase(connectionString)
                    .WithScriptsEmbeddedInAssembly(Assembly.GetExecutingAssembly())
                    .LogToConsole()
                    .Build();

            var upgradeScriptingEngine = new ScriptingUpgrader(connectionString, upgrader);


            if (ShowResult(initResult))
            {
                if (ShowResult(upgradeScriptingEngine.Run(args)))
                {
                    return 1;
                }
            }
            return 0;
        }

        private static bool ShowResult(DatabaseUpgradeResult result)
        {
            if (!result.Successful)
            {
                Console.ForegroundColor = ConsoleColor.Red;
                Console.WriteLine(result.Error);
                Console.ResetColor();
                return false;
            }
            else
            {
                Console.ForegroundColor = ConsoleColor.Green;
                Console.WriteLine("Success! - " + string.Join(Environment.NewLine, result.Scripts.Select(x => x.Name)));
                Console.ResetColor();
                return true;
            }
        }

```