### PR TITLE
Extra keyword for the regex that decides what to script

### DIFF
--- a/DbUp.Support.SqlServer.Scripting/DbObjectScripter.cs
+++ b/DbUp.Support.SqlServer.Scripting/DbObjectScripter.cs
@@ -18,7 +18,7 @@ namespace DbUp.Support.SqlServer.Scripting
 {
     public class DbObjectScripter
     {
-        private readonly string m_scrptingObjectRegEx = @"(CREATE|ALTER|DROP)\s*(TABLE|VIEW|PROCEDURE|FUNCTION|SYNONYM|TYPE) ([\w\[\]\-]+)?\.?([\w\[\]\-]*)";
+        private readonly string m_scrptingObjectRegEx = @"(CREATE|ALTER|DROP)\s*(TABLE|VIEW|PROCEDURE|PROC|FUNCTION|SYNONYM|TYPE) ([\w\[\]\-]+)?\.?([\w\[\]\-]*)";
         private Options m_options;
         private string m_definitionDirectory;
         private SqlConnectionStringBuilder m_connectionBuilder;


### PR DESCRIPTION
Hi,

Thanks for the library! It has proven very useful to our work. 

We had this issue where some changes that a colleague made were not being scripted and after having a look around we realized that we were using the reserved keyword `PROC` instead of `PROCEDURE`. The regex that decides what to script did not include it and hence was not detecting our changes. 

This small change should fix it. Let me know if you have any comments. 

Thanks!
Mike