### PR TITLE
Bugfix and several new Features

### DIFF
--- a/DbUp.Support.SqlServer.Scripting/DbObjectScripter.cs
+++ b/DbUp.Support.SqlServer.Scripting/DbObjectScripter.cs
@@ -74,12 +74,19 @@ namespace DbUp.Support.SqlServer.Scripting
                     ScriptAllUserDefinedTypes(context);
                 });
 
+                var functionsScriptTask = Task.Run(() =>
+                {
+                    var context = GetDatabaseContext(true);
+                    this.ScriptAllFunctions(context);
+                });
+
                 Task.WaitAll(
                     tablesScriptTask,
                     viewsScriptTask,
                     storedProceduresScriptTask,
                     synonymsScriptTask,
-                    udtScriptTask
+                    udtScriptTask,
+                    functionsScriptTask
                 );
             }
             catch (Exception ex)

--- a/DbUp.Support.SqlServer.Scripting/DbObjectScripter.cs
+++ b/DbUp.Support.SqlServer.Scripting/DbObjectScripter.cs
@@ -489,6 +489,13 @@ namespace DbUp.Support.SqlServer.Scripting
                 {
                     sb.Append(str);
                     sb.Append(Environment.NewLine);
+                    
+                    if (this.m_options.ScriptBatchTerminator)
+                    {
+                        sb.Append("GO");
+                        sb.Append(Environment.NewLine);
+                        sb.Append(Environment.NewLine);
+                    }
                 }
 
                 m_log.WriteInformation(string.Format("Saving object definition: {0}", Path.Combine(outputDirectory, scriptObject.FileName)));

--- a/DbUp.Support.SqlServer.Scripting/ObjectTypeEnum.cs
+++ b/DbUp.Support.SqlServer.Scripting/ObjectTypeEnum.cs
@@ -9,6 +9,7 @@ namespace DbUp.Support.SqlServer.Scripting
     [Flags]
     public enum ObjectTypeEnum : int
     {
+        Undefined = 0,
         Table = 1,
         View = 2,
         Procedure = 4,

--- a/DbUp.Support.SqlServer.Scripting/Options.cs
+++ b/DbUp.Support.SqlServer.Scripting/Options.cs
@@ -46,6 +46,7 @@ namespace DbUp.Support.SqlServer.Scripting
         public string FolderNameProcedures { get; set; }
         public string FolderNameFunctions { get; set; }
         public string FolderNameSynonyms { get; set; }
+        public bool ScriptBatchTerminator { get; set; }
         public ObjectTypeEnum ObjectsToInclude { get; set; }
     }
 }

--- a/DbUp.Support.SqlServer.Scripting/ScriptingUpgrader.cs
+++ b/DbUp.Support.SqlServer.Scripting/ScriptingUpgrader.cs
@@ -120,14 +120,22 @@ namespace DbUp
                 }
                 else
                 {
+                    var executedScriptsBeforeUpgrade = this.m_engine.GetExecutedScripts();
                     result = m_engine.PerformUpgrade();
-
-                    if (result.Successful
-                        && args.Any(a => "--fromconsole".Equals(a.Trim(), StringComparison.InvariantCultureIgnoreCase)))
+                    if (args.Any(a => "--fromconsole".Equals(a.Trim(), StringComparison.InvariantCultureIgnoreCase)))
                     {
-                        this.Log.WriteInformation("Scripting changed database objects...");
-                        var scripter = new DbObjectScripter(this.ConnectionString, m_options, this.Log);
-                        var scriptorResult = scripter.ScriptMigrationTargets(scriptsToExecute);
+                        var scripter = new DbObjectScripter(this.ConnectionString, this.m_options, this.Log);
+                        if (result.Successful)
+                        {
+                            this.Log.WriteInformation("Scripting changed database objects...");
+                            var scriptorResult = scripter.ScriptMigrationTargets(scriptsToExecute);
+                        } else
+                        { 
+                            this.Log.WriteInformation("Scripting successfully changed database objects...");
+                            var executedScriptsAfterUpgrade = this.m_engine.GetExecutedScripts();
+                            var appliedScripts = scriptsToExecute.Where(s => executedScriptsAfterUpgrade.Except(executedScriptsBeforeUpgrade).Contains(s.Name))
+                            var scriptorResult = scripter.ScriptMigrationTargets(appliedScripts);
+                        }
                     }
                 }
             }

--- a/DbUp.Support.SqlServer.Scripting/ScriptingUpgrader.cs
+++ b/DbUp.Support.SqlServer.Scripting/ScriptingUpgrader.cs
@@ -133,7 +133,8 @@ namespace DbUp
                         { 
                             this.Log.WriteInformation("Scripting successfully changed database objects...");
                             var executedScriptsAfterUpgrade = this.m_engine.GetExecutedScripts();
-                            var appliedScripts = scriptsToExecute.Where(s => executedScriptsAfterUpgrade.Except(executedScriptsBeforeUpgrade).Contains(s.Name))
+                            var appliedScripts = scriptsToExecute.Where(s => executedScriptsAfterUpgrade.Except(executedScriptsBeforeUpgrade)
+                                                                                                        .Contains(s.Name));
                             var scriptorResult = scripter.ScriptMigrationTargets(appliedScripts);
                         }
                     }

--- a/DbUp.Support.SqlServer.Scripting/ScriptingUpgrader.cs
+++ b/DbUp.Support.SqlServer.Scripting/ScriptingUpgrader.cs
@@ -129,7 +129,8 @@ namespace DbUp
                         {
                             this.Log.WriteInformation("Scripting changed database objects...");
                             var scriptorResult = scripter.ScriptMigrationTargets(scriptsToExecute);
-                        } else
+                        } 
+                        else
                         { 
                             this.Log.WriteInformation("Scripting successfully changed database objects...");
                             var executedScriptsAfterUpgrade = this.m_engine.GetExecutedScripts();

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The following SQL Server object types are currently supported:
 * Stored Procedures
 * User Defined Functions
 * Synonyms
+* User Defined Types
 
 ## Script All Definitions
 You can run `Start-DatabaseScript` from the Package Manager Console to script all objects in the database.  If working with an existing database, it is recommended to run this command initially so that all your definition files are saved.  

--- a/README.md
+++ b/README.md
@@ -71,6 +71,21 @@ The following SQL Server object types are currently supported:
 * Synonyms
 * User Defined Types
 
+## Statement Types
+The following list shows which statement types are currently supported:
+
+* CREATE
+* CREATE OR ALTER
+* ALTER
+* CREATE
+* CREATE IF EXISTS
+* Renaming with sp_rename
+
+## Known Issues
+* Renaming with sp_rename
+** Only the renaming of objects itself (like table, view, procedures, etc.) is supported, but not the renaming of columns, indexes, keys
+** When dropping or again renaming an object after it has been renamed with sp_rename, those objects can not be properly scripted
+
 ## Script All Definitions
 You can run `Start-DatabaseScript` from the Package Manager Console to script all objects in the database.  If working with an existing database, it is recommended to run this command initially so that all your definition files are saved.  
 


### PR DESCRIPTION
So, we required some features in the office for the dbup-scripter, since we are heavily dependent on database, and use the dbup pretty often. I decided it was probably easiest to implement them myself, so here we go.

Bugfixes:

- When called with --scriptAllDefinitions functions weren't scripted. This is fixed now

Features
- Added new Option "ScriptBatchTerminator" which, if set to true, inserts GO (and a newline) between all batches of the definition
- When the migration is unsuccessful, the migrator now analyzes which scripts were successfully applied and scripts the definitions for those. This makes sure, that no defintions are lost, when an error occurs during migration
- If objects have changed multiple times during migration, all except the newest get removed from the list of objects to script. This a) achieves better performance and b) avoids errors, when an object has been changed and later been dropped during the same migration run
- added support for SQL 2016 features CREATE OR ALTER and DROP IF EXISTS
- added support for renaming objects with sp_rename. This creates a Drop for the original name and a create for the new name

this last feature has been somewhat of a pain to implement, but I got it to run in the end. This lead to a pretty complicated regex. Also sp_rename allows the renaming of columns, indexes and keys, which I have not implemented, and am not sure how to best do that (it's certainly possible, but will require further changes). Also, to find out what type of object has been renamed, I need to scan the db context. This sadly also means, that if an object has been renamed and later dropped (or renamed again), its impossible to find out what object type needs to be scripted. In this case a warning gets printed in the end, to inform the user he has to check the file manually and delete it if necessary.

If you have any request for changes, please let me know. I have tried to keep my changes as clean as possible, but I'll gladly implement some feedback if we can use that in our code soon :)

Regards,
Max

Edit: by the way, I tested the changes on our database. Around 220 scripts with sometimes pretty elaborate migrations. Besides the above named problems regarding renaming of indexes and the like, and the problem when using sp_rename and later dropping the object, everything worked perfectly 